### PR TITLE
4 week

### DIFF
--- a/records/4Week_김연준.md
+++ b/records/4Week_김연준.md
@@ -25,24 +25,32 @@
 
 
 - 성별, 호감사유 필터링 기능
-  - 컨트롤러에서 gender라는 이름의 파라미터를 받는다.
+  - 컨트롤러에서 gender, attractiveTypeCode라는 이름의 파라미터를 받는다.
   - 컨트롤러에서 받은 파라미터를 querydsl레파지토리까지 전달
-  - 처음 toList페이지를 들어갈 때 null값이 전달되는 것을 고려하여 service단에서 처리하지 않고 querydsl로 처리함
-  - BooleanExpression은 null일 경우 null을 반환하고 where절에서 자동으로 사라지는 특성이 있으므로 이를 활용
+  - 처음 toList페이지를 들어갈 때 조건 파라미터들이 null값으로 전달되는 것을 고려하여 service단에서 처리하지 않고 querydsl로 처리함
+  - BooleanExpression은 null일 경우 null을 반환하고 where절에서 자동으로 사라지는 특성이 있으므로 유연하게 동적쿼리에 대응
   - null이 아니라면 BooleanExpression는 원하는 필터링 조건을 반환하고 where절에 주입
 - 정렬 기능
   - orderby절에는 표현식으로 OrderSpecifier클래스를 받으므로 이를 반환하는 sortByField 메소드를 구성
-  - 클라이언트로부터 1~6의 정렬 옵션 중 하나를 파라미터로 받아 switch문으로 각각의 옵션 처리 
+  - 클라이언트로부터 sortCode라는 1~6의 정렬 옵션 중 하나를 파라미터로 받아 switch문으로 각각의 옵션 처리 
+  - 5, 6번 옵션은 다중 옵션이므로 sortByField메소드에서 OrderSpecifier[]와 같이 옵션을 배열에 담아 반환 
   - 정렬옵션을 선택하지 않을 때 기본으로 실행되는 옵션은 최신날짜순이므로 옵션파라미터가 null이거나 공백이면 기본옵션을 실행하게 처리
-  - OrderSpecifier의 Expression 매개변수로 실제 엔티티에 존재하는 필드만 인식한다.
+  - OrderSpecifier의 Expression 매개변수로 실제 엔티티에 존재하는 필드(데이터베이스에 등록된 필드)만 인식한다.
   - 인기 순으로 정렬하려면 호감을 표시한 인스타 멤버의 총 like 갯수로 판단해야하므로 InstaMemberBase에 likes필드를 추가
-
+- 도메인, HTTPS적용
+  - iwantmyname에서 도메인을 구입하고 dnszi에서 관리를 하여 도메인이 네이버 클라우드서버에서 받은 공인ip를 가르키도록 A레코드 설정
+  - 접속용 포트인 443, 80 관리자 포트인 81번을 npm을 도입하여 전부 몰아준다.
+  - npm에서 SSL인증서 발급받고 https적용
 
 **[특이사항]**
 
 아쉬웠던 점
-
+- 인기 순 정렬에 likes를 기준으로 판단 할 다른 방법이 생각나지 않아 OrderSpecifier규격에 맞추려고 likes필드를 추가시켜 테이블 구조를 바꾼 것
+- 배포 과정에 대해 전반적인 이해가 부족한 상태여서 다시 공부할 필요성을 느낌
+- 젠킨스 자동 배포를 하지 못한 점
 
 궁금했던 점
+- 서비스단과 DB단의 정렬 처리 중 상황에 따라서 어느 방법이 좋은지 구체적으로 알고싶습니다.
+
 
 **[Refactoring]**

--- a/records/4Week_김연준.md
+++ b/records/4Week_김연준.md
@@ -1,0 +1,48 @@
+# 4Week_김연준.md
+
+## Title: [4Week] 김연준
+
+### 필수 미션 요구사항 분석 & 체크리스트
+- [x] 네이버클라우드플랫폼을 통한 배포, 도메인, HTTPS 까지 적용
+- [x] 내가 받은 호감리스트(/usr/likeablePerson/toList)에서 성별 필터링기능 구현
+### 선택 미션 요구사항 분석 & 체크리스트
+- [x] 젠킨스를 통해서 리포지터리의 main 브랜치에 커밋 이벤트가 발생하면 자동으로 배포가 진행되도록
+- [x] 내가 받은 호감리스트(/usr/likeablePerson/toList)에서 호감사유 필터링기능 구현
+- [x] 내가 받은 호감리스트(/usr/likeablePerson/toList)에서 정렬기능
+---
+
+-  젠킨스를 통해서 리포지터리의 main 브랜치에 커밋 이벤트가 발생하면 자동으로 배포가 진행되도록 (미구현)
+-  내가 받은 호감리스트(/usr/likeablePerson/toList)에서 호감사유 필터링기능 구현 (구현)
+-  내가 받은 호감리스트(/usr/likeablePerson/toList)에서 정렬기능 (구현)
+-  네이버클라우드플랫폼을 통한 배포, 도메인, HTTPS 까지 적용 (구현)
+-  내가 받은 호감리스트(/usr/likeablePerson/toList)에서 성별 필터링기능 구현 (구현)
+### 4주차 미션 요약
+
+---
+
+**[접근 방법]**
+
+
+
+- 성별, 호감사유 필터링 기능
+  - 컨트롤러에서 gender라는 이름의 파라미터를 받는다.
+  - 컨트롤러에서 받은 파라미터를 querydsl레파지토리까지 전달
+  - 처음 toList페이지를 들어갈 때 null값이 전달되는 것을 고려하여 service단에서 처리하지 않고 querydsl로 처리함
+  - BooleanExpression은 null일 경우 null을 반환하고 where절에서 자동으로 사라지는 특성이 있으므로 이를 활용
+  - null이 아니라면 BooleanExpression는 원하는 필터링 조건을 반환하고 where절에 주입
+- 정렬 기능
+  - orderby절에는 표현식으로 OrderSpecifier클래스를 받으므로 이를 반환하는 sortByField 메소드를 구성
+  - 클라이언트로부터 1~6의 정렬 옵션 중 하나를 파라미터로 받아 switch문으로 각각의 옵션 처리 
+  - 정렬옵션을 선택하지 않을 때 기본으로 실행되는 옵션은 최신날짜순이므로 옵션파라미터가 null이거나 공백이면 기본옵션을 실행하게 처리
+  - OrderSpecifier의 Expression 매개변수로 실제 엔티티에 존재하는 필드만 인식한다.
+  - 인기 순으로 정렬하려면 호감을 표시한 인스타 멤버의 총 like 갯수로 판단해야하므로 InstaMemberBase에 likes필드를 추가
+
+
+**[특이사항]**
+
+아쉬웠던 점
+
+
+궁금했던 점
+
+**[Refactoring]**

--- a/src/main/java/com/ll/gramgram/base/initData/NotProd.java
+++ b/src/main/java/com/ll/gramgram/base/initData/NotProd.java
@@ -40,22 +40,22 @@ public class NotProd {
             @Override
             @Transactional
             public void run(String... args) throws Exception {
-//                Member memberAdmin = memberService.join("admin", "1234").getData();
-//                Member memberUser1 = memberService.join("user1", "1234").getData();
-//                Member memberUser2 = memberService.join("user2", "1234").getData();
-//                Member memberUser3 = memberService.join("user3", "1234").getData();
-//                Member memberUser4 = memberService.join("user4", "1234").getData();
-//                Member memberUser5 = memberService.join("user5", "1234").getData();
+                Member memberAdmin = memberService.join("admin", "1234").getData();
+                Member memberUser1 = memberService.join("user1", "1234").getData();
+                Member memberUser2 = memberService.join("user2", "1234").getData();
+                Member memberUser3 = memberService.join("user3", "1234").getData();
+                Member memberUser4 = memberService.join("user4", "1234").getData();
+                Member memberUser5 = memberService.join("user5", "1234").getData();
 
                 Member memberUser6ByKakao = memberService.whenSocialLogin("KAKAO", "KAKAO__%s".formatted(kakaoDevUserOAuthId)).getData();
                 Member memberUser7ByGoogle = memberService.whenSocialLogin("GOOGLE", "GOOGLE__%s".formatted(googleDevUserOAuthId)).getData();
                 Member memberUser8ByNaver = memberService.whenSocialLogin("NAVER", "NAVER__%s".formatted(naverDevUserOAuthId)).getData();
                 Member memberUser9ByFacebook = memberService.whenSocialLogin("FACEBOOK", "FACEBOOK__%s".formatted(facebookDevUserOAuthId)).getData();
 
-//                instaMemberService.connect(memberUser2, "insta_user2", "M");
-//                instaMemberService.connect(memberUser3, "insta_user3", "W");
-//                instaMemberService.connect(memberUser4, "insta_user4", "M");
-//                instaMemberService.connect(memberUser5, "insta_user5", "W");
+                instaMemberService.connect(memberUser2, "insta_user2", "M");
+                instaMemberService.connect(memberUser3, "insta_user3", "W");
+                instaMemberService.connect(memberUser4, "insta_user4", "M");
+                instaMemberService.connect(memberUser5, "insta_user5", "W");
 
                 instaMemberService.connect(memberUser6ByKakao, "111", "W");
                 instaMemberService.connect(memberUser7ByGoogle, "222", "M");
@@ -63,12 +63,12 @@ public class NotProd {
                 instaMemberService.connect(memberUser9ByFacebook, "444", "W");
 
                 // 원활한 테스트와 개발을 위해서 자동으로 만들어지는 호감이 삭제, 수정이 가능하도록 쿨타임해제
-//                LikeablePerson likeablePersonToInstaUser4 = likeablePersonService.like(memberUser3, "insta_user4", 1).getData();
-//                Ut.reflection.setFieldValue(likeablePersonToInstaUser4, "modifyUnlockDate", LocalDateTime.now().minusSeconds(1));
-//                LikeablePerson likeablePersonToInstaUser100 = likeablePersonService.like(memberUser3, "insta_user100", 2).getData();
-//                Ut.reflection.setFieldValue(likeablePersonToInstaUser100, "modifyUnlockDate", LocalDateTime.now().minusSeconds(1));
+                LikeablePerson likeablePersonToInstaUser4 = likeablePersonService.like(memberUser3, "insta_user4", 1).getData();
+                Ut.reflection.setFieldValue(likeablePersonToInstaUser4, "modifyUnlockDate", LocalDateTime.now().minusSeconds(1));
+                LikeablePerson likeablePersonToInstaUser100 = likeablePersonService.like(memberUser3, "insta_user100", 2).getData();
+                Ut.reflection.setFieldValue(likeablePersonToInstaUser100, "modifyUnlockDate", LocalDateTime.now().minusSeconds(1));
 
-//                LikeablePerson likeablePersonToInstaUserAbcd = likeablePersonService.like(memberUser3, "insta_user_abcd", 2).getData();
+                LikeablePerson likeablePersonToInstaUserAbcd = likeablePersonService.like(memberUser3, "insta_user_abcd", 2).getData();
 
                 LikeablePerson a = likeablePersonService.like(memberUser6ByKakao, "222", 3).getData();
                 LikeablePerson b = likeablePersonService.like(memberUser7ByGoogle, "111", 2).getData();

--- a/src/main/java/com/ll/gramgram/base/initData/NotProd.java
+++ b/src/main/java/com/ll/gramgram/base/initData/NotProd.java
@@ -52,18 +52,22 @@ public class NotProd {
                 Member memberUser8ByNaver = memberService.whenSocialLogin("NAVER", "NAVER__%s".formatted(naverDevUserOAuthId)).getData();
                 Member memberUser9ByFacebook = memberService.whenSocialLogin("FACEBOOK", "FACEBOOK__%s".formatted(facebookDevUserOAuthId)).getData();
 
-                instaMemberService.connect(memberUser2, "insta_user2", "M");
-                instaMemberService.connect(memberUser3, "insta_user3", "W");
-                instaMemberService.connect(memberUser4, "insta_user4", "M");
-                instaMemberService.connect(memberUser5, "insta_user5", "W");
+                instaMemberService.connect(memberUser6ByKakao, "111", "W");
+                instaMemberService.connect(memberUser7ByGoogle, "222", "M");
+                instaMemberService.connect(memberUser8ByNaver, "333", "W");
+                instaMemberService.connect(memberUser9ByFacebook, "444", "W");
 
                 // 원활한 테스트와 개발을 위해서 자동으로 만들어지는 호감이 삭제, 수정이 가능하도록 쿨타임해제
-                LikeablePerson likeablePersonToInstaUser4 = likeablePersonService.like(memberUser3, "insta_user4", 1).getData();
-                Ut.reflection.setFieldValue(likeablePersonToInstaUser4, "modifyUnlockDate", LocalDateTime.now().minusSeconds(1));
-                LikeablePerson likeablePersonToInstaUser100 = likeablePersonService.like(memberUser3, "insta_user100", 2).getData();
-                Ut.reflection.setFieldValue(likeablePersonToInstaUser100, "modifyUnlockDate", LocalDateTime.now().minusSeconds(1));
+//                LikeablePerson likeablePersonToInstaUser4 = likeablePersonService.like(memberUser3, "insta_user4", 1).getData();
+//                Ut.reflection.setFieldValue(likeablePersonToInstaUser4, "modifyUnlockDate", LocalDateTime.now().minusSeconds(1));
+//                LikeablePerson likeablePersonToInstaUser100 = likeablePersonService.like(memberUser3, "insta_user100", 2).getData();
+//                Ut.reflection.setFieldValue(likeablePersonToInstaUser100, "modifyUnlockDate", LocalDateTime.now().minusSeconds(1));
 
                 LikeablePerson likeablePersonToInstaUserAbcd = likeablePersonService.like(memberUser3, "insta_user_abcd", 2).getData();
+                LikeablePerson a = likeablePersonService.like(memberUser6ByKakao, "222", 3).getData();
+                LikeablePerson b = likeablePersonService.like(memberUser7ByGoogle, "111", 2).getData();
+                LikeablePerson c = likeablePersonService.like(memberUser8ByNaver, "111", 3).getData();
+                LikeablePerson d = likeablePersonService.like(memberUser9ByFacebook, "111", 1).getData();
             }
         };
     }

--- a/src/main/java/com/ll/gramgram/base/initData/NotProd.java
+++ b/src/main/java/com/ll/gramgram/base/initData/NotProd.java
@@ -40,17 +40,22 @@ public class NotProd {
             @Override
             @Transactional
             public void run(String... args) throws Exception {
-                Member memberAdmin = memberService.join("admin", "1234").getData();
-                Member memberUser1 = memberService.join("user1", "1234").getData();
-                Member memberUser2 = memberService.join("user2", "1234").getData();
-                Member memberUser3 = memberService.join("user3", "1234").getData();
-                Member memberUser4 = memberService.join("user4", "1234").getData();
-                Member memberUser5 = memberService.join("user5", "1234").getData();
+//                Member memberAdmin = memberService.join("admin", "1234").getData();
+//                Member memberUser1 = memberService.join("user1", "1234").getData();
+//                Member memberUser2 = memberService.join("user2", "1234").getData();
+//                Member memberUser3 = memberService.join("user3", "1234").getData();
+//                Member memberUser4 = memberService.join("user4", "1234").getData();
+//                Member memberUser5 = memberService.join("user5", "1234").getData();
 
                 Member memberUser6ByKakao = memberService.whenSocialLogin("KAKAO", "KAKAO__%s".formatted(kakaoDevUserOAuthId)).getData();
                 Member memberUser7ByGoogle = memberService.whenSocialLogin("GOOGLE", "GOOGLE__%s".formatted(googleDevUserOAuthId)).getData();
                 Member memberUser8ByNaver = memberService.whenSocialLogin("NAVER", "NAVER__%s".formatted(naverDevUserOAuthId)).getData();
                 Member memberUser9ByFacebook = memberService.whenSocialLogin("FACEBOOK", "FACEBOOK__%s".formatted(facebookDevUserOAuthId)).getData();
+
+//                instaMemberService.connect(memberUser2, "insta_user2", "M");
+//                instaMemberService.connect(memberUser3, "insta_user3", "W");
+//                instaMemberService.connect(memberUser4, "insta_user4", "M");
+//                instaMemberService.connect(memberUser5, "insta_user5", "W");
 
                 instaMemberService.connect(memberUser6ByKakao, "111", "W");
                 instaMemberService.connect(memberUser7ByGoogle, "222", "M");
@@ -63,7 +68,8 @@ public class NotProd {
 //                LikeablePerson likeablePersonToInstaUser100 = likeablePersonService.like(memberUser3, "insta_user100", 2).getData();
 //                Ut.reflection.setFieldValue(likeablePersonToInstaUser100, "modifyUnlockDate", LocalDateTime.now().minusSeconds(1));
 
-                LikeablePerson likeablePersonToInstaUserAbcd = likeablePersonService.like(memberUser3, "insta_user_abcd", 2).getData();
+//                LikeablePerson likeablePersonToInstaUserAbcd = likeablePersonService.like(memberUser3, "insta_user_abcd", 2).getData();
+
                 LikeablePerson a = likeablePersonService.like(memberUser6ByKakao, "222", 3).getData();
                 LikeablePerson b = likeablePersonService.like(memberUser7ByGoogle, "111", 2).getData();
                 LikeablePerson c = likeablePersonService.like(memberUser8ByNaver, "111", 3).getData();

--- a/src/main/java/com/ll/gramgram/boundedContext/instaMember/entity/InstaMember.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/instaMember/entity/InstaMember.java
@@ -54,7 +54,10 @@ public class InstaMember extends InstaMemberBase {
     public void removeToLikeablePerson(LikeablePerson likeablePerson) {
         toLikeablePeople.removeIf(e -> e.equals(likeablePerson));
     }
-
+    //좋아요 전체 갯수
+    public void updateLikes() {
+        this.likes = getLikes();
+    }
     public String getGenderDisplayName() {
         return switch (gender) {
             case "W" -> "여성";

--- a/src/main/java/com/ll/gramgram/boundedContext/instaMember/entity/InstaMemberBase.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/instaMember/entity/InstaMemberBase.java
@@ -16,6 +16,8 @@ import lombok.experimental.SuperBuilder;
 public abstract class InstaMemberBase extends BaseEntity {
     @Setter
     String gender;
+    //OrderSpecifier의 Expression으로 이용하여 정렬 조건에 만족시키기 위해 컬럼 추가
+    long likes;
 
     long likesCountByGenderWomanAndAttractiveTypeCode1;
     long likesCountByGenderWomanAndAttractiveTypeCode2;

--- a/src/main/java/com/ll/gramgram/boundedContext/instaMember/service/InstaMemberService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/instaMember/service/InstaMemberService.java
@@ -97,6 +97,8 @@ public class InstaMemberService {
 
         toInstaMember.decreaseLikesCount(fromInstaMember.getGender(), oldAttractiveTypeCode);
         toInstaMember.increaseLikesCount(fromInstaMember.getGender(), likeablePerson.getAttractiveTypeCode());
+        //좋아요 업데이트
+        toInstaMember.updateLikes();
 
         InstaMemberSnapshot snapshot = toInstaMember.snapshot("ModifyAttractiveType");
 
@@ -108,6 +110,8 @@ public class InstaMemberService {
         InstaMember toInstaMember = likeablePerson.getToInstaMember();
 
         toInstaMember.increaseLikesCount(fromInstaMember.getGender(), likeablePerson.getAttractiveTypeCode());
+        //좋아요 업데이트
+        toInstaMember.updateLikes();
 
         InstaMemberSnapshot snapshot = toInstaMember.snapshot("Like");
 
@@ -121,6 +125,8 @@ public class InstaMemberService {
         InstaMember toInstaMember = likeablePerson.getToInstaMember();
 
         toInstaMember.decreaseLikesCount(fromInstaMember.getGender(), likeablePerson.getAttractiveTypeCode());
+        //좋아요 업데이트
+        toInstaMember.updateLikes();
 
         InstaMemberSnapshot snapshot = toInstaMember.snapshot("CancelLike");
 

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -10,6 +10,7 @@ import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -120,28 +121,22 @@ public class LikeablePersonController {
         return rq.redirectWithMsg("/usr/likeablePerson/list", rsData);
     }
 
-    @AllArgsConstructor
-    @Getter
+    @Setter
     public static class ToListCondition {
-        private final String gender = null;
-        private final int attractiveTypeCode = 0;
-        private final int sortCode = 0;
+        private String gender = "";
+        private int attractiveTypeCode = 0;
+        private int sortCode = 1;
     }
 
     @PreAuthorize("isAuthenticated()")
     @GetMapping("/toList")
-    public String showToList(
-            Model model,
-            @RequestParam(value = "gender", required = false) String gender,
-            @RequestParam(value = "attractiveTypeCode", required = false) String attractiveTypeCode,
-            @RequestParam(value = "sortCode", required = false) String sortCode
-    ) {
+    public String showToList(Model model, ToListCondition toListCondition) {
         InstaMember instaMember = rq.getMember().getInstaMember();
 
         // 인스타인증을 했는지 체크
         if (instaMember != null) {
             // 해당 인스타회원이 좋아하는 사람들 목록
-            RsData<List<LikeablePerson>> likeablePeople = likeablePersonService.findToLikeByCondition(instaMember, gender, attractiveTypeCode, sortCode);
+            RsData<List<LikeablePerson>> likeablePeople = likeablePersonService.findToLikeByCondition(instaMember, toListCondition.gender, toListCondition.attractiveTypeCode, toListCondition.sortCode);
             model.addAttribute("likeablePeople", likeablePeople.getData());
         }
 

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -133,7 +133,7 @@ public class LikeablePersonController {
     public String showToList(
             Model model,
             @RequestParam(value = "gender", required = false) String gender,
-            @RequestParam(value = "attractiveTypeCode", required = false) Integer attractiveTypeCode
+            @RequestParam(value = "attractiveTypeCode", required = false) String attractiveTypeCode
     ) {
         InstaMember instaMember = rq.getMember().getInstaMember();
 

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -120,16 +120,28 @@ public class LikeablePersonController {
         return rq.redirectWithMsg("/usr/likeablePerson/list", rsData);
     }
 
+    @AllArgsConstructor
+    @Getter
+    public static class ToListCondition {
+        private final String gender = null;
+        private final int attractiveTypeCode = 0;
+        private final int sortCode = 0;
+    }
+
     @PreAuthorize("isAuthenticated()")
     @GetMapping("/toList")
-    public String showToList(Model model) {
+    public String showToList(
+            Model model,
+            @RequestParam(value = "gender", required = false) String gender,
+            @RequestParam(value = "attractiveTypeCode", required = false) Integer attractiveTypeCode
+    ) {
         InstaMember instaMember = rq.getMember().getInstaMember();
 
         // 인스타인증을 했는지 체크
         if (instaMember != null) {
             // 해당 인스타회원이 좋아하는 사람들 목록
-            List<LikeablePerson> likeablePeople = instaMember.getToLikeablePeople();
-            model.addAttribute("likeablePeople", likeablePeople);
+            RsData<List<LikeablePerson>> likeablePeople = likeablePersonService.findToLikeByCondition(instaMember, gender, attractiveTypeCode);
+            model.addAttribute("likeablePeople", likeablePeople.getData());
         }
 
         return "usr/likeablePerson/toList";

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -133,14 +133,15 @@ public class LikeablePersonController {
     public String showToList(
             Model model,
             @RequestParam(value = "gender", required = false) String gender,
-            @RequestParam(value = "attractiveTypeCode", required = false) String attractiveTypeCode
+            @RequestParam(value = "attractiveTypeCode", required = false) String attractiveTypeCode,
+            @RequestParam(value = "sortCode", required = false) String sortCode
     ) {
         InstaMember instaMember = rq.getMember().getInstaMember();
 
         // 인스타인증을 했는지 체크
         if (instaMember != null) {
             // 해당 인스타회원이 좋아하는 사람들 목록
-            RsData<List<LikeablePerson>> likeablePeople = likeablePersonService.findToLikeByCondition(instaMember, gender, attractiveTypeCode);
+            RsData<List<LikeablePerson>> likeablePeople = likeablePersonService.findToLikeByCondition(instaMember, gender, attractiveTypeCode, sortCode);
             model.addAttribute("likeablePeople", likeablePeople.getData());
         }
 

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepositoryCustom.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepositoryCustom.java
@@ -9,5 +9,5 @@ import java.util.Optional;
 public interface LikeablePersonRepositoryCustom {
     Optional<LikeablePerson> findQslByFromInstaMemberIdAndToInstaMember_username(long fromInstaMemberId, String toInstaMemberUsername);
 
-    List<LikeablePerson> findQslByGenderAndAttractiveTypeCode(InstaMember instaMember, String gender, Integer attractiveTypeCode);
+    List<LikeablePerson> findQslByGenderAndAttractiveTypeCode(InstaMember instaMember, String gender, String attractiveTypeCode);
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepositoryCustom.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepositoryCustom.java
@@ -9,5 +9,5 @@ import java.util.Optional;
 public interface LikeablePersonRepositoryCustom {
     Optional<LikeablePerson> findQslByFromInstaMemberIdAndToInstaMember_username(long fromInstaMemberId, String toInstaMemberUsername);
 
-    List<LikeablePerson> findQslByGenderAndAttractiveTypeCode(InstaMember instaMember, String gender, String attractiveTypeCode, String sortCode);
+    List<LikeablePerson> findQslByGenderAndAttractiveTypeCode(InstaMember instaMember, String gender, int attractiveTypeCode, int sortCode);
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepositoryCustom.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepositoryCustom.java
@@ -9,5 +9,5 @@ import java.util.Optional;
 public interface LikeablePersonRepositoryCustom {
     Optional<LikeablePerson> findQslByFromInstaMemberIdAndToInstaMember_username(long fromInstaMemberId, String toInstaMemberUsername);
 
-    List<LikeablePerson> findQslByGenderAndAttractiveTypeCode(InstaMember instaMember, String gender, String attractiveTypeCode);
+    List<LikeablePerson> findQslByGenderAndAttractiveTypeCode(InstaMember instaMember, String gender, String attractiveTypeCode, String sortCode);
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepositoryCustom.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepositoryCustom.java
@@ -1,9 +1,13 @@
 package com.ll.gramgram.boundedContext.likeablePerson.repository;
 
+import com.ll.gramgram.boundedContext.instaMember.entity.InstaMember;
 import com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface LikeablePersonRepositoryCustom {
     Optional<LikeablePerson> findQslByFromInstaMemberIdAndToInstaMember_username(long fromInstaMemberId, String toInstaMemberUsername);
+
+    List<LikeablePerson> findQslByGenderAndAttractiveTypeCode(InstaMember instaMember, String gender, Integer attractiveTypeCode);
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepositoryImpl.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepositoryImpl.java
@@ -34,7 +34,7 @@ public class LikeablePersonRepositoryImpl implements LikeablePersonRepositoryCus
     }
 
     @Override
-    public List<LikeablePerson> findQslByGenderAndAttractiveTypeCode(InstaMember instaMember, String gender, String attractiveTypeCode, String sortCode) {
+    public List<LikeablePerson> findQslByGenderAndAttractiveTypeCode(InstaMember instaMember, String gender, int attractiveTypeCode, int sortCode) {
         return
                 jpaQueryFactory
                         .selectFrom(likeablePerson)
@@ -50,50 +50,45 @@ public class LikeablePersonRepositoryImpl implements LikeablePersonRepositoryCus
         return likeablePerson.toInstaMember.eq(instaMember);
     }
     private BooleanExpression eqGender(String gender) {
-        if(gender == null || gender.isEmpty()) {
+        if(gender.isEmpty()) {
             return null;
         }
         return likeablePerson.fromInstaMember.gender.eq(gender);
     }
 
-    private BooleanExpression eqAttractiveTypeCode(InstaMember instaMember, String attractiveTypeCode) {
-        if(attractiveTypeCode == null || attractiveTypeCode.isEmpty()) {
+    private BooleanExpression eqAttractiveTypeCode(InstaMember instaMember, int attractiveTypeCode) {
+        if(attractiveTypeCode == 0) {
             return null;
         }
-        return likeablePerson.attractiveTypeCode.eq(Integer.valueOf(attractiveTypeCode));
+        return likeablePerson.attractiveTypeCode.eq(attractiveTypeCode);
     }
 
-    private OrderSpecifier[] sortByField(String sortCode) {
+    private OrderSpecifier[] sortByField(int sortCode) {
 
         List<OrderSpecifier> orderSpecifiers = new ArrayList<>();
 
-        // NULL 처리
-        sortCode = (sortCode == null) ? "" : sortCode;
 
         switch (sortCode) {
-            case "1" -> orderSpecifiers.add(new OrderSpecifier<>(Order.DESC, likeablePerson.createDate));
-            case "2" -> orderSpecifiers.add(new OrderSpecifier<>(Order.ASC, likeablePerson.createDate));
-            case "3" -> {
+            case 1 -> orderSpecifiers.add(new OrderSpecifier<>(Order.DESC, likeablePerson.createDate));
+            case 2 -> orderSpecifiers.add(new OrderSpecifier<>(Order.ASC, likeablePerson.createDate));
+            case 3 -> {
                 orderSpecifiers.add(new OrderSpecifier<>(Order.DESC, likeablePerson.fromInstaMember.likes));
                 orderSpecifiers.add(new OrderSpecifier<>(Order.DESC, likeablePerson.createDate));
             }
-            case "4" -> {
+            case 4 -> {
                 orderSpecifiers.add(new OrderSpecifier<>(Order.ASC, likeablePerson.fromInstaMember.likes));
                 orderSpecifiers.add(new OrderSpecifier<>(Order.DESC, likeablePerson.createDate));
             }
-            case "5" -> {
+            case 5 -> {
                 orderSpecifiers.add(new OrderSpecifier<>(Order.DESC, likeablePerson.fromInstaMember.gender));
                 orderSpecifiers.add(new OrderSpecifier<>(Order.DESC, likeablePerson.createDate));
             }
-            case "6" -> {
+            case 6 -> {
                 orderSpecifiers.add(new OrderSpecifier<>(Order.ASC, likeablePerson.attractiveTypeCode));
                 orderSpecifiers.add(new OrderSpecifier<>(Order.DESC, likeablePerson.createDate));
             }
-            default -> orderSpecifiers.add(new OrderSpecifier<>(Order.DESC, likeablePerson.createDate));
         }
         //다중 정렬 조건을 고려하여 배열로 반환
         return orderSpecifiers.toArray(new OrderSpecifier[orderSpecifiers.size()]);
     }
-
-
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepositoryImpl.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepositoryImpl.java
@@ -31,11 +31,11 @@ public class LikeablePersonRepositoryImpl implements LikeablePersonRepositoryCus
     }
 
     @Override
-    public List<LikeablePerson> findQslByGenderAndAttractiveTypeCode(InstaMember instaMember, String gender, Integer attractiveTypeCode) {
+    public List<LikeablePerson> findQslByGenderAndAttractiveTypeCode(InstaMember instaMember, String gender, String attractiveTypeCode) {
         return
                 jpaQueryFactory
                         .selectFrom(likeablePerson)
-                        .where(eqInsta(instaMember), eqGender(gender))
+                        .where(eqInsta(instaMember), eqGender(gender), eqAttractiveTypeCode(instaMember, attractiveTypeCode))
                         .fetch();
     }
 
@@ -51,4 +51,13 @@ public class LikeablePersonRepositoryImpl implements LikeablePersonRepositoryCus
         }
         return likeablePerson.fromInstaMember.gender.eq(gender);
     }
+
+    private BooleanExpression eqAttractiveTypeCode(InstaMember instaMember, String attractiveTypeCode) {
+        if(attractiveTypeCode == null || attractiveTypeCode.isEmpty()) {
+            return null;
+        }
+        return likeablePerson.attractiveTypeCode.eq(Integer.valueOf(attractiveTypeCode));
+    }
+
+
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepositoryImpl.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepositoryImpl.java
@@ -1,9 +1,12 @@
 package com.ll.gramgram.boundedContext.likeablePerson.repository;
 
+import com.ll.gramgram.boundedContext.instaMember.entity.InstaMember;
 import com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
+import java.util.List;
 import java.util.Optional;
 
 import static com.ll.gramgram.boundedContext.likeablePerson.entity.QLikeablePerson.likeablePerson;
@@ -25,5 +28,27 @@ public class LikeablePersonRepositoryImpl implements LikeablePersonRepositoryCus
                         )
                         .fetchOne()
         );
+    }
+
+    @Override
+    public List<LikeablePerson> findQslByGenderAndAttractiveTypeCode(InstaMember instaMember, String gender, Integer attractiveTypeCode) {
+        return
+                jpaQueryFactory
+                        .selectFrom(likeablePerson)
+                        .where(eqInsta(instaMember), eqGender(gender))
+                        .fetch();
+    }
+
+    private BooleanExpression eqInsta(InstaMember instaMember) {
+        if(instaMember == null) {
+            return null;
+        }
+        return likeablePerson.toInstaMember.eq(instaMember);
+    }
+    private BooleanExpression eqGender(String gender) {
+        if(gender == null || gender.isEmpty()) {
+            return null;
+        }
+        return likeablePerson.fromInstaMember.gender.eq(gender);
     }
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepositoryImpl.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepositoryImpl.java
@@ -2,11 +2,18 @@ package com.ll.gramgram.boundedContext.likeablePerson.repository;
 
 import com.ll.gramgram.boundedContext.instaMember.entity.InstaMember;
 import com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson;
+import com.querydsl.core.types.NullExpression;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Path;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.PathBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static com.ll.gramgram.boundedContext.likeablePerson.entity.QLikeablePerson.likeablePerson;
@@ -31,11 +38,12 @@ public class LikeablePersonRepositoryImpl implements LikeablePersonRepositoryCus
     }
 
     @Override
-    public List<LikeablePerson> findQslByGenderAndAttractiveTypeCode(InstaMember instaMember, String gender, String attractiveTypeCode) {
+    public List<LikeablePerson> findQslByGenderAndAttractiveTypeCode(InstaMember instaMember, String gender, String attractiveTypeCode, String sortCode) {
         return
                 jpaQueryFactory
                         .selectFrom(likeablePerson)
                         .where(eqInsta(instaMember), eqGender(gender), eqAttractiveTypeCode(instaMember, attractiveTypeCode))
+                        .orderBy(sortByField(sortCode))
                         .fetch();
     }
 
@@ -57,6 +65,38 @@ public class LikeablePersonRepositoryImpl implements LikeablePersonRepositoryCus
             return null;
         }
         return likeablePerson.attractiveTypeCode.eq(Integer.valueOf(attractiveTypeCode));
+    }
+
+    private OrderSpecifier[] sortByField(String sortCode) {
+
+        List<OrderSpecifier> orderSpecifiers = new ArrayList<>();
+
+        // NULL 처리
+        sortCode = (sortCode == null) ? "" : sortCode;
+
+        switch (sortCode) {
+            case "1" -> orderSpecifiers.add(new OrderSpecifier<>(Order.DESC, likeablePerson.createDate));
+            case "2" -> orderSpecifiers.add(new OrderSpecifier<>(Order.ASC, likeablePerson.createDate));
+            case "3" -> {
+                orderSpecifiers.add(new OrderSpecifier<>(Order.DESC, likeablePerson.fromInstaMember.likes));
+                orderSpecifiers.add(new OrderSpecifier<>(Order.DESC, likeablePerson.createDate));
+            }
+            case "4" -> {
+                orderSpecifiers.add(new OrderSpecifier<>(Order.ASC, likeablePerson.fromInstaMember.likes));
+                orderSpecifiers.add(new OrderSpecifier<>(Order.DESC, likeablePerson.createDate));
+            }
+            case "5" -> {
+                orderSpecifiers.add(new OrderSpecifier<>(Order.DESC, likeablePerson.fromInstaMember.gender));
+                orderSpecifiers.add(new OrderSpecifier<>(Order.DESC, likeablePerson.createDate));
+            }
+            case "6" -> {
+                orderSpecifiers.add(new OrderSpecifier<>(Order.ASC, likeablePerson.attractiveTypeCode));
+                orderSpecifiers.add(new OrderSpecifier<>(Order.DESC, likeablePerson.createDate));
+            }
+            default -> orderSpecifiers.add(new OrderSpecifier<>(Order.DESC, likeablePerson.createDate));
+        }
+        //다중 정렬 조건을 고려하여 배열로 반환
+        return orderSpecifiers.toArray(new OrderSpecifier[orderSpecifiers.size()]);
     }
 
 

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepositoryImpl.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepositoryImpl.java
@@ -2,18 +2,14 @@ package com.ll.gramgram.boundedContext.likeablePerson.repository;
 
 import com.ll.gramgram.boundedContext.instaMember.entity.InstaMember;
 import com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson;
-import com.querydsl.core.types.NullExpression;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
-import com.querydsl.core.types.Path;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.PathBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import static com.ll.gramgram.boundedContext.likeablePerson.entity.QLikeablePerson.likeablePerson;

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -10,21 +10,14 @@ import com.ll.gramgram.boundedContext.instaMember.service.InstaMemberService;
 import com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson;
 import com.ll.gramgram.boundedContext.likeablePerson.repository.LikeablePersonRepository;
 import com.ll.gramgram.boundedContext.member.entity.Member;
-import com.querydsl.core.types.NullExpression;
-import com.querydsl.core.types.Order;
-import com.querydsl.core.types.OrderSpecifier;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
-
-import static com.ll.gramgram.boundedContext.likeablePerson.entity.QLikeablePerson.likeablePerson;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -220,7 +220,7 @@ public class LikeablePersonService {
         return RsData.of("S-1", "호감사유변경이 가능합니다.");
     }
 
-    public RsData<List<LikeablePerson>> findToLikeByCondition(InstaMember instaMember, String gender, String attractiveTypeCode, String sortCode) {
+    public RsData<List<LikeablePerson>> findToLikeByCondition(InstaMember instaMember, String gender, int attractiveTypeCode, int sortCode) {
 
         List<LikeablePerson> result = likeablePersonRepository.findQslByGenderAndAttractiveTypeCode(instaMember, gender, attractiveTypeCode, sortCode);
         return RsData.successOf(result);

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -221,7 +221,7 @@ public class LikeablePersonService {
         return RsData.of("S-1", "호감사유변경이 가능합니다.");
     }
 
-    public RsData<List<LikeablePerson>> findToLikeByCondition(InstaMember instaMember, String gender, Integer attractiveTypeCode) {
+    public RsData<List<LikeablePerson>> findToLikeByCondition(InstaMember instaMember, String gender, String attractiveTypeCode) {
         List<LikeablePerson> list = instaMember.getToLikeablePeople();
         if (gender == null && attractiveTypeCode == null) {
             return RsData.failOf(list);

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -10,15 +10,21 @@ import com.ll.gramgram.boundedContext.instaMember.service.InstaMemberService;
 import com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson;
 import com.ll.gramgram.boundedContext.likeablePerson.repository.LikeablePersonRepository;
 import com.ll.gramgram.boundedContext.member.entity.Member;
+import com.querydsl.core.types.NullExpression;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
+
+import static com.ll.gramgram.boundedContext.likeablePerson.entity.QLikeablePerson.likeablePerson;
 
 @Service
 @RequiredArgsConstructor
@@ -221,12 +227,9 @@ public class LikeablePersonService {
         return RsData.of("S-1", "호감사유변경이 가능합니다.");
     }
 
-    public RsData<List<LikeablePerson>> findToLikeByCondition(InstaMember instaMember, String gender, String attractiveTypeCode) {
-        List<LikeablePerson> list = instaMember.getToLikeablePeople();
-        if (gender == null && attractiveTypeCode == null) {
-            return RsData.failOf(list);
-        }
-        List<LikeablePerson> result = likeablePersonRepository.findQslByGenderAndAttractiveTypeCode(instaMember, gender, attractiveTypeCode);
+    public RsData<List<LikeablePerson>> findToLikeByCondition(InstaMember instaMember, String gender, String attractiveTypeCode, String sortCode) {
+
+        List<LikeablePerson> result = likeablePersonRepository.findQslByGenderAndAttractiveTypeCode(instaMember, gender, attractiveTypeCode, sortCode);
         return RsData.successOf(result);
     }
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -18,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -218,5 +219,14 @@ public class LikeablePersonService {
 
 
         return RsData.of("S-1", "호감사유변경이 가능합니다.");
+    }
+
+    public RsData<List<LikeablePerson>> findToLikeByCondition(InstaMember instaMember, String gender, Integer attractiveTypeCode) {
+        List<LikeablePerson> list = instaMember.getToLikeablePeople();
+        if (gender == null && attractiveTypeCode == null) {
+            return RsData.failOf(list);
+        }
+        List<LikeablePerson> result = likeablePersonRepository.findQslByGenderAndAttractiveTypeCode(instaMember, gender, attractiveTypeCode);
+        return RsData.successOf(result);
     }
 }

--- a/src/main/resources/templates/usr/likeablePerson/toList.html
+++ b/src/main/resources/templates/usr/likeablePerson/toList.html
@@ -52,7 +52,7 @@
                             </label>
                             <select name="attractiveTypeCode" class="select select-bordered w-full"
                                     onchange="$(this).closest('form').submit();">
-                                <option value="">전체</option>
+                                <option value="0">전체</option>
                                 <option value="1">외모</option>
                                 <option value="2">성격</option>
                                 <option value="3">능력</option>

--- a/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonServiceTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonServiceTests.java
@@ -266,27 +266,27 @@ public class LikeablePersonServiceTests {
         ).isTrue();
     }
     
-    @DisplayName("toList에서 성별 필터링기능 구현")
-    @Test
-    void t009() throws Exception {
-
-        Member memberUser1 = memberService.join("user1", "1234").getData();
-        Member memberUser2 = memberService.join("user2", "1234").getData();
-        Member memberUser3 = memberService.join("user3", "1234").getData();
-        Member memberUser4 = memberService.join("user4", "1234").getData();
-        InstaMember instaMember1 = instaMemberService.connect(memberUser1, "insta_user1", "W").getData();
-        InstaMember instaMember2 = instaMemberService.connect(memberUser2, "insta_user2", "M").getData();
-        InstaMember instaMember3 = instaMemberService.connect(memberUser3, "insta_user3", "W").getData();
-        InstaMember instaMember4 = instaMemberService.connect(memberUser4, "insta_user4", "W").getData();
-        // memberUser2~4(insta_user2~4)는 insta_user1을 호감표시함
-        likeablePersonService.like(memberUser2, "insta_user1", 1).getData();
-        likeablePersonService.like(memberUser3, "insta_user1", 2).getData();
-        likeablePersonService.like(memberUser4, "insta_user1", 3).getData();
-        // insta_user1이 받은 호감 리스트를 남자만 필터링하여 불러온다.
-        List<LikeablePerson> likeByCondition = likeablePersonService.findToLikeByCondition(instaMember1, "M", "", "").getData();
-        // 필터링이 잘 되었다면 리스트 중 첫번 째 목록의 성별이 남자일 것이다.
-        Assertions
-                .assertThat(likeByCondition.get(0).getFromInstaMember().getGender())
-                .isEqualTo("M");
-    }
+//    @DisplayName("toList에서 성별 필터링기능 구현")
+//    @Test
+//    void t009() throws Exception {
+//
+//        Member memberUser1 = memberService.join("user1", "1234").getData();
+//        Member memberUser2 = memberService.join("user2", "1234").getData();
+//        Member memberUser3 = memberService.join("user3", "1234").getData();
+//        Member memberUser4 = memberService.join("user4", "1234").getData();
+//        InstaMember instaMember1 = instaMemberService.connect(memberUser1, "insta_user1", "W").getData();
+//        InstaMember instaMember2 = instaMemberService.connect(memberUser2, "insta_user2", "M").getData();
+//        InstaMember instaMember3 = instaMemberService.connect(memberUser3, "insta_user3", "W").getData();
+//        InstaMember instaMember4 = instaMemberService.connect(memberUser4, "insta_user4", "W").getData();
+//        // memberUser2~4(insta_user2~4)는 insta_user1을 호감표시함
+//        likeablePersonService.like(memberUser2, "insta_user1", 1).getData();
+//        likeablePersonService.like(memberUser3, "insta_user1", 2).getData();
+//        likeablePersonService.like(memberUser4, "insta_user1", 3).getData();
+//        // insta_user1이 받은 호감 리스트를 남자만 필터링하여 불러온다.
+//        List<LikeablePerson> likeByCondition = likeablePersonService.findToLikeByCondition(instaMember1, "M", "", "").getData();
+//        // 필터링이 잘 되었다면 리스트 중 첫번 째 목록의 성별이 남자일 것이다.
+//        Assertions
+//                .assertThat(likeByCondition.get(0).getFromInstaMember().getGender())
+//                .isEqualTo("M");
+//    }
 }

--- a/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonServiceTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonServiceTests.java
@@ -3,15 +3,15 @@ package com.ll.gramgram.boundedContext.likeablePerson.service;
 
 import com.ll.gramgram.TestUt;
 import com.ll.gramgram.base.appConfig.AppConfig;
+import com.ll.gramgram.base.rsData.RsData;
 import com.ll.gramgram.boundedContext.instaMember.entity.InstaMember;
+import com.ll.gramgram.boundedContext.instaMember.service.InstaMemberService;
 import com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson;
 import com.ll.gramgram.boundedContext.likeablePerson.repository.LikeablePersonRepository;
 import com.ll.gramgram.boundedContext.member.entity.Member;
 import com.ll.gramgram.boundedContext.member.service.MemberService;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -29,6 +29,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class LikeablePersonServiceTests {
     @Autowired
     private MemberService memberService;
+    @Autowired
+    private InstaMemberService instaMemberService;
     @Autowired
     private LikeablePersonService likeablePersonService;
     @Autowired
@@ -262,5 +264,29 @@ public class LikeablePersonServiceTests {
         assertThat(
                 likeablePersonToBts.getModifyUnlockDate().isAfter(coolTime)
         ).isTrue();
+    }
+    
+    @DisplayName("toList에서 성별 필터링기능 구현")
+    @Test
+    void t009() throws Exception {
+
+        Member memberUser1 = memberService.join("user1", "1234").getData();
+        Member memberUser2 = memberService.join("user2", "1234").getData();
+        Member memberUser3 = memberService.join("user3", "1234").getData();
+        Member memberUser4 = memberService.join("user4", "1234").getData();
+        InstaMember instaMember1 = instaMemberService.connect(memberUser1, "insta_user1", "W").getData();
+        InstaMember instaMember2 = instaMemberService.connect(memberUser2, "insta_user2", "M").getData();
+        InstaMember instaMember3 = instaMemberService.connect(memberUser3, "insta_user3", "W").getData();
+        InstaMember instaMember4 = instaMemberService.connect(memberUser4, "insta_user4", "W").getData();
+        // memberUser2~4(insta_user2~4)는 insta_user1을 호감표시함
+        likeablePersonService.like(memberUser2, "insta_user1", 1).getData();
+        likeablePersonService.like(memberUser3, "insta_user1", 2).getData();
+        likeablePersonService.like(memberUser4, "insta_user1", 3).getData();
+        // insta_user1이 받은 호감 리스트를 남자만 필터링하여 불러온다.
+        List<LikeablePerson> likeByCondition = likeablePersonService.findToLikeByCondition(instaMember1, "M", "", "").getData();
+        // 필터링이 잘 되었다면 리스트 중 첫번 째 목록의 성별이 남자일 것이다.
+        Assertions
+                .assertThat(likeByCondition.get(0).getFromInstaMember().getGender())
+                .isEqualTo("M");
     }
 }

--- a/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonServiceTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonServiceTests.java
@@ -266,27 +266,27 @@ public class LikeablePersonServiceTests {
         ).isTrue();
     }
     
-//    @DisplayName("toList에서 성별 필터링기능 구현")
-//    @Test
-//    void t009() throws Exception {
-//
-//        Member memberUser1 = memberService.join("user1", "1234").getData();
-//        Member memberUser2 = memberService.join("user2", "1234").getData();
-//        Member memberUser3 = memberService.join("user3", "1234").getData();
-//        Member memberUser4 = memberService.join("user4", "1234").getData();
-//        InstaMember instaMember1 = instaMemberService.connect(memberUser1, "insta_user1", "W").getData();
-//        InstaMember instaMember2 = instaMemberService.connect(memberUser2, "insta_user2", "M").getData();
-//        InstaMember instaMember3 = instaMemberService.connect(memberUser3, "insta_user3", "W").getData();
-//        InstaMember instaMember4 = instaMemberService.connect(memberUser4, "insta_user4", "W").getData();
-//        // memberUser2~4(insta_user2~4)는 insta_user1을 호감표시함
-//        likeablePersonService.like(memberUser2, "insta_user1", 1).getData();
-//        likeablePersonService.like(memberUser3, "insta_user1", 2).getData();
-//        likeablePersonService.like(memberUser4, "insta_user1", 3).getData();
-//        // insta_user1이 받은 호감 리스트를 남자만 필터링하여 불러온다.
-//        List<LikeablePerson> likeByCondition = likeablePersonService.findToLikeByCondition(instaMember1, "M", "", "").getData();
-//        // 필터링이 잘 되었다면 리스트 중 첫번 째 목록의 성별이 남자일 것이다.
-//        Assertions
-//                .assertThat(likeByCondition.get(0).getFromInstaMember().getGender())
-//                .isEqualTo("M");
-//    }
+    @DisplayName("toList에서 성별 필터링기능 구현")
+    @Test
+    void t009() throws Exception {
+
+        Member memberUser1 = memberService.findByUsername("user1").orElseThrow();
+        Member memberUser2 = memberService.findByUsername("user2").orElseThrow();
+        Member memberUser3 = memberService.findByUsername("user3").orElseThrow();
+        Member memberUser4 = memberService.findByUsername("user4").orElseThrow();
+        InstaMember instaMember1 = instaMemberService.connect(memberUser1, "insta_user1", "W").getData();
+        InstaMember instaMember2 = instaMemberService.connect(memberUser2, "insta_user2", "M").getData();
+        InstaMember instaMember3 = instaMemberService.connect(memberUser3, "insta_user3", "M").getData();
+        InstaMember instaMember4 = instaMemberService.connect(memberUser4, "insta_user4", "W").getData();
+        // memberUser2~4(insta_user2~4)는 insta_user1을 호감표시함
+        likeablePersonService.like(memberUser2, "insta_user1", 1).getData();
+        likeablePersonService.like(memberUser3, "insta_user1", 2).getData();
+        likeablePersonService.like(memberUser4, "insta_user1", 3).getData();
+        // insta_user1이 받은 호감 리스트를 남자만 필터링하여 불러온다.
+        List<LikeablePerson> likeByCondition = likeablePersonService.findToLikeByCondition(instaMember1, "M", 0, 1).getData();
+        // 필터링이 잘 되었다면 리스트 중 첫번 째 목록의 성별이 남자일 것이다.
+        Assertions
+                .assertThat(likeByCondition.get(0).getFromInstaMember().getGender())
+                .isEqualTo("M");
+    }
 }


### PR DESCRIPTION
# 4Week_김연준.md

## Title: [4Week] 김연준

### 필수 미션 요구사항 분석 & 체크리스트
- [x] 네이버클라우드플랫폼을 통한 배포, 도메인, HTTPS 까지 적용
- [x] 내가 받은 호감리스트(/usr/likeablePerson/toList)에서 성별 필터링기능 구현
### 선택 미션 요구사항 분석 & 체크리스트
- [x] 젠킨스를 통해서 리포지터리의 main 브랜치에 커밋 이벤트가 발생하면 자동으로 배포가 진행되도록
- [x] 내가 받은 호감리스트(/usr/likeablePerson/toList)에서 호감사유 필터링기능 구현
- [x] 내가 받은 호감리스트(/usr/likeablePerson/toList)에서 정렬기능
---

-  젠킨스를 통해서 리포지터리의 main 브랜치에 커밋 이벤트가 발생하면 자동으로 배포가 진행되도록 (미구현)
-  내가 받은 호감리스트(/usr/likeablePerson/toList)에서 호감사유 필터링기능 구현 (구현)
-  내가 받은 호감리스트(/usr/likeablePerson/toList)에서 정렬기능 (구현)
-  네이버클라우드플랫폼을 통한 배포, 도메인, HTTPS 까지 적용 (구현)
-  내가 받은 호감리스트(/usr/likeablePerson/toList)에서 성별 필터링기능 구현 (구현)
### 4주차 미션 요약

---

**[접근 방법]**



- 성별, 호감사유 필터링 기능
  - 컨트롤러에서 gender, attractiveTypeCode라는 이름의 파라미터를 받는다.
  - 컨트롤러에서 받은 파라미터를 querydsl레파지토리까지 전달
  - 처음 toList페이지를 들어갈 때 조건 파라미터들이 null값으로 전달되는 것을 고려하여 service단에서 처리하지 않고 querydsl로 처리함
  - BooleanExpression은 null일 경우 null을 반환하고 where절에서 자동으로 사라지는 특성이 있으므로 유연하게 동적쿼리에 대응
  - null이 아니라면 BooleanExpression는 원하는 필터링 조건을 반환하고 where절에 주입
- 정렬 기능
  - orderby절에는 표현식으로 OrderSpecifier클래스를 받으므로 이를 반환하는 sortByField 메소드를 구성
  - 클라이언트로부터 sortCode라는 1~6의 정렬 옵션 중 하나를 파라미터로 받아 switch문으로 각각의 옵션 처리 
  - 5, 6번 옵션은 다중 옵션이므로 sortByField메소드에서 OrderSpecifier[]와 같이 옵션을 배열에 담아 반환 
  - 정렬옵션을 선택하지 않을 때 기본으로 실행되는 옵션은 최신날짜순이므로 옵션파라미터가 null이거나 공백이면 기본옵션을 실행하게 처리
  - OrderSpecifier의 Expression 매개변수로 실제 엔티티에 존재하는 필드(데이터베이스에 등록된 필드)만 인식한다.
  - 인기 순으로 정렬하려면 호감을 표시한 인스타 멤버의 총 like 갯수로 판단해야하므로 InstaMemberBase에 likes필드를 추가
- 도메인, HTTPS적용
  - iwantmyname에서 도메인을 구입하고 dnszi에서 관리를 하여 도메인이 네이버 클라우드서버에서 받은 공인ip를 가르키도록 A레코드 설정
  - 접속용 포트인 443, 80 관리자 포트인 81번을 npm을 도입하여 전부 몰아준다.
  - npm에서 SSL인증서 발급받고 https적용

**[특이사항]**

아쉬웠던 점
- 인기 순 정렬에 likes를 기준으로 판단 할 다른 방법이 생각나지 않아 OrderSpecifier규격에 맞추려고 likes필드를 추가시켜 테이블 구조를 바꾼 것
- 배포 과정에 대해 전반적인 이해가 부족한 상태여서 다시 공부할 필요성을 느낌
- 젠킨스 자동 배포를 하지 못한 점

궁금했던 점
- 서비스단과 DB단의 정렬 처리 중 상황에 따라서 어느 방법이 좋은지 구체적으로 알고싶습니다.


**[Refactoring]**